### PR TITLE
Revert-previous-changes

### DIFF
--- a/pages/simulation/sim.mdx
+++ b/pages/simulation/sim.mdx
@@ -47,6 +47,13 @@ make install-third-party-external
 ```
 
 ### Running Stompy experiments
+
+Before running the experiments, you must run these commands to fix dependency issues:
+```bash
+pip install matplotlib==3.3.4 numpy==1.19.5 wandb tensorboard
+conda install nvidia/label/cuda-12.0.0::cuda-nvrtc
+```
+
 1. Pre-define model directory:
 ```bash
 export MODEL_DIR=sim/resources/stompymini

--- a/pages/simulation/sim.mdx
+++ b/pages/simulation/sim.mdx
@@ -48,12 +48,6 @@ make install-third-party-external
 
 ### Running Stompy experiments
 
-Before running the experiments, you must run these commands to fix dependency issues:
-```bash
-pip install matplotlib==3.3.4 numpy==1.19.5 wandb tensorboard
-conda install nvidia/label/cuda-12.0.0::cuda-nvrtc
-```
-
 1. Pre-define model directory:
 ```bash
 export MODEL_DIR=sim/resources/stompymini


### PR DESCRIPTION
The commands are now part of `make install-dev` and `make install-third-party-external`, so no need to run them manually or to have them in docs.